### PR TITLE
chore: promote node-hello to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-staging/node-hello/node-hello-ingress.yaml
+++ b/config-root/namespaces/jx-staging/node-hello/node-hello-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: node-hello/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: node-hello
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: node-hello
+              servicePort: 80
+      host: node-hello-jx-staging.35.184.128.47.nip.io

--- a/config-root/namespaces/jx-staging/node-hello/node-hello-node-hello-deploy.yaml
+++ b/config-root/namespaces/jx-staging/node-hello/node-hello-node-hello-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: node-hello/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: node-hello-node-hello
+  labels:
+    draft: draft-app
+    chart: "node-hello-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: node-hello-node-hello
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: node-hello-node-hello
+    spec:
+      serviceAccountName: node-hello-node-hello
+      containers:
+        - name: node-hello
+          image: "gcr.io/jenkinsx-2021/node-hello:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/node-hello/node-hello-node-hello-sa.yaml
+++ b/config-root/namespaces/jx-staging/node-hello/node-hello-node-hello-sa.yaml
@@ -1,0 +1,8 @@
+# Source: node-hello/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-hello-node-hello
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/node-hello/node-hello-svc.yaml
+++ b/config-root/namespaces/jx-staging/node-hello/node-hello-svc.yaml
@@ -1,0 +1,18 @@
+# Source: node-hello/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-hello
+  labels:
+    chart: "node-hello-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: node-hello-node-hello

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,12 @@
 	      <td></td>
 	    </tr>
     <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> node-hello </a></td>
+	      <td>0.0.1</td>
+	      <td><a href='http://node-hello-jx-staging.35.184.128.47.nip.io'>view</a></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='4'><h3>jx</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -60,6 +60,19 @@
     repositoryUrl: http://chartmuseum-jx.35.184.128.47.nip.io/
     resourcePath: config-root/namespaces/jx-staging/php
     version: 0.0.1
+  - apiVersion: v1
+    applicationUrl: http://node-hello-jx-staging.35.184.128.47.nip.io
+    description: A Helm chart for Kubernetes
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    ingresses:
+    - name: node-hello
+      url: http://node-hello-jx-staging.35.184.128.47.nip.io
+    logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=jenkinsx-2021&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Ftf-jx-tolerant-boxer%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Fnode-hello&dateRangeUnbound=both
+    name: node-hello
+    repositoryName: dev
+    repositoryUrl: http://chartmuseum-jx.35.184.128.47.nip.io/
+    resourcePath: config-root/namespaces/jx-staging/node-hello
+    version: 0.0.1
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -24,5 +24,7 @@ releases:
   version: 0.0.1
   name: node-hello
   namespace: jx-staging
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -20,5 +20,9 @@ releases:
   namespace: jx-staging
   values:
   - jx-values.yaml
+- chart: dev/node-hello
+  version: 0.0.1
+  name: node-hello
+  namespace: jx-staging
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote node-hello to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
