### PR TITLE
chore: promote node-hello to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-production/node-hello/node-hello-ingress.yaml
+++ b/config-root/namespaces/jx-production/node-hello/node-hello-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: node-hello/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: node-hello
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: node-hello
+              servicePort: 80
+      host: node-hello-jx-production.35.184.128.47.nip.io

--- a/config-root/namespaces/jx-production/node-hello/node-hello-node-hello-deploy.yaml
+++ b/config-root/namespaces/jx-production/node-hello/node-hello-node-hello-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: node-hello/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: node-hello-node-hello
+  labels:
+    draft: draft-app
+    chart: "node-hello-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-production
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: node-hello-node-hello
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: node-hello-node-hello
+    spec:
+      serviceAccountName: node-hello-node-hello
+      containers:
+        - name: node-hello
+          image: "gcr.io/jenkinsx-2021/node-hello:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/node-hello/node-hello-node-hello-sa.yaml
+++ b/config-root/namespaces/jx-production/node-hello/node-hello-node-hello-sa.yaml
@@ -1,0 +1,8 @@
+# Source: node-hello/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-hello-node-hello
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/node-hello/node-hello-svc.yaml
+++ b/config-root/namespaces/jx-production/node-hello/node-hello-svc.yaml
@@ -1,0 +1,18 @@
+# Source: node-hello/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-hello
+  labels:
+    chart: "node-hello-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: node-hello-node-hello

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,12 @@
 	      <td><a href='https://github.com/jenkins-x/jx-verify'>source</a></td>
 	    </tr>
     <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> node-hello </a></td>
+	      <td>0.0.1</td>
+	      <td><a href='http://node-hello-jx-production.35.184.128.47.nip.io'>view</a></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='4'><h3>jx-staging</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -34,6 +34,19 @@
     repositoryName: jx3
     repositoryUrl: https://storage.googleapis.com/jenkinsxio/charts
     resourcePath: config-root/namespaces/jx-production/jx-verify
+  - apiVersion: v1
+    applicationUrl: http://node-hello-jx-production.35.184.128.47.nip.io
+    description: A Helm chart for Kubernetes
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    ingresses:
+    - name: node-hello
+      url: http://node-hello-jx-production.35.184.128.47.nip.io
+    logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=jenkinsx-2021&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Ftf-jx-tolerant-boxer%2Fnamespace_name%2Fjx-production%2Fcontainer_name%2Fnode-hello&dateRangeUnbound=both
+    name: node-hello
+    repositoryName: dev
+    repositoryUrl: http://chartmuseum-jx.35.184.128.47.nip.io/
+    resourcePath: config-root/namespaces/jx-production/node-hello
+    version: 0.0.1
 - namespace: jx-staging
   path: helmfiles/jx-staging/helmfile.yaml
   releases:

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -6,11 +6,17 @@ environments:
 repositories:
 - name: jx3
   url: https://storage.googleapis.com/jenkinsxio/charts
+- name: dev
+  url: http://chartmuseum-jx.35.184.128.47.nip.io/
 releases:
 - chart: jx3/jx-verify
   name: jx-verify
   namespace: jx-production
   values:
   - jx-values.yaml
+- chart: dev/node-hello
+  version: 0.0.1
+  name: node-hello
+  namespace: jx-production
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -18,5 +18,7 @@ releases:
   version: 0.0.1
   name: node-hello
   namespace: jx-production
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote node-hello to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
