### PR TITLE
chore: promote node-hello to version 0.0.2

### DIFF
--- a/config-root/namespaces/jx-staging/node-hello/node-hello-node-hello-deploy.yaml
+++ b/config-root/namespaces/jx-staging/node-hello/node-hello-node-hello-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: node-hello-node-hello
   labels:
     draft: draft-app
-    chart: "node-hello-0.0.1"
+    chart: "node-hello-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: node-hello-node-hello
       containers:
         - name: node-hello
-          image: "gcr.io/jenkinsx-2021/node-hello:0.0.1"
+          image: "gcr.io/jenkinsx-2021/node-hello:0.0.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.2
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/node-hello/node-hello-svc.yaml
+++ b/config-root/namespaces/jx-staging/node-hello/node-hello-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: node-hello
   labels:
-    chart: "node-hello-0.0.1"
+    chart: "node-hello-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
 spec:

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> node-hello </a></td>
-	      <td>0.0.1</td>
+	      <td>0.0.2</td>
 	      <td><a href='http://node-hello-jx-staging.35.184.128.47.nip.io'>view</a></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -72,7 +72,7 @@
     repositoryName: dev
     repositoryUrl: http://chartmuseum-jx.35.184.128.47.nip.io/
     resourcePath: config-root/namespaces/jx-staging/node-hello
-    version: 0.0.1
+    version: 0.0.2
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -21,7 +21,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/node-hello
-  version: 0.0.1
+  version: 0.0.2
   name: node-hello
   namespace: jx-staging
   values:


### PR DESCRIPTION
chore: promote node-hello to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
